### PR TITLE
Add support for changing the interval via a command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,21 @@ Send batch requests for ICMP and show results in a console window to monitor ava
 
 ## Usage
 
-`$ ./icmp_watch hostname [...hostname]`
+`$ ./icmp_watch [option]... hostname...`
+
+(Multiple hostnames can be specified.)
+
+Valid options are:
+
+* `-i` or `--interval`: specify how long in seconds to wait for replies (real numbers, e.g. 1.5 are allowed, default is 1 second)
+* `-h` or `--help`: show help text
 
 Press Q or ESC to stop monitoring.
 
 
 ## Function
 
-This tool will batch test availability by sending out N ICMP-request, and then wait up to 1 second for N replies.
+This tool will batch test availability by sending out N ICMP-requests, and then wait up to 1 second  for N replies.
 
 Hosts that do not reply will be marked in RED, others in GREEN with the response time shown in milliseconds.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Press Q or ESC to stop monitoring.
 
 ## Function
 
-This tool will batch test availability by sending out N ICMP-requests, and then wait up to 1 second  for N replies.
+This tool will batch test availability by sending out N ICMP-requests, and then wait up to 1 second for N replies.
 
 Hosts that do not reply will be marked in RED, others in GREEN with the response time shown in milliseconds.
 

--- a/icmp_watch.c
+++ b/icmp_watch.c
@@ -193,7 +193,7 @@ int main(int argc, char* argv[])
 		return 1;
 	}
 	
-	struct timeval timeout = {1, 0};    // seconds, microseconds.
+	struct timeval default_timeout = {1, 0};    // seconds, microseconds.
 	
 	// Parse command line options (we'll break out of the loop)
 	while(1) {
@@ -258,6 +258,7 @@ int main(int argc, char* argv[])
 		const int numr = read(STDIN_FILENO, &c, 1);
 		if (numr == 1 && (c == 27 || c == 'q' || c == 'Q'))
 			done = 1;
+		struct timeval timeout = default_timeout;
 		ping_all(cnt, dst, response_times, &timeout);
 		fprintf(stdout, CLEARSCREEN);
 		for (int i = 0; i < cnt; ++i)

--- a/icmp_watch.c
+++ b/icmp_watch.c
@@ -189,7 +189,7 @@ void print_help(char *progname) {
 	// Restyled the help to more closely match the --help text for mv, etc.
 	printf("Usage: %s [option]... destination_ip...\n"
 		   "Send batch requests for ICMP and show the results\n\n"
-		   "  -i, --interval=INTERVAL\tspecify how long to wait for replies (real numbers, e.g. 1.5 are allowed)\n"
+		   "  -i, --interval=INTERVAL\tspecify how long in seconds to wait for replies (real numbers, e.g. 1.5 are allowed)\n"
 		   "  -h, --help\t\t\tshow this help\n", progname);
 }
 

--- a/icmp_watch.c
+++ b/icmp_watch.c
@@ -188,7 +188,7 @@ static int get_ip_addresses(int cnt, char** hosts, int args_left, struct in_addr
 void print_help(char *progname) {
 	// Restyled the help to more closely match the --help text for mv, etc.
 	printf("Usage: %s [option]... destination_ip...\n"
-		   "Send batch requests for ICMP and show the results\n\n"
+		   "Send batch requests for ICMP and show the results\nPress q or escape to exit\n\n"
 		   "  -i, --interval=INTERVAL\tspecify how long in seconds to wait for replies (real numbers, e.g. 1.5 are allowed)\n"
 		   "  -h, --help\t\t\tshow this help\n", progname);
 }


### PR DESCRIPTION
This adds a way to parse command line options, and, for now, 2 valid flags, -i (or --interval), and --help (or -h)

It also changes the help text and readme to mention them