### PR TITLE
(draft) Add IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ Send batch requests for ICMP and show results in a console window to monitor ava
 ## Limitations
 
  * Uses ICMP sockets, which means that sysctl net.ipv4.ping_group_range needs to be set properly. (My Ubuntu 22.04 was configured correctly for this, by default.)
- * For now, IPv4 only, but adding IPv6 support shouldn't be hard.
- * Update frequency is currently hard-coded to 1 second.
-
 
 ## Usage
 
@@ -20,6 +17,7 @@ Send batch requests for ICMP and show results in a console window to monitor ava
 Valid options are:
 
 * `-i` or `--interval`: specify how long in seconds to wait for replies (real numbers, e.g. 1.5 are allowed, default is 1 second)
+* `-4` and `-6`: restrict to only using IPv4 or IPv6 respectively
 * `-h` or `--help`: show help text
 
 Press Q or ESC to stop monitoring.
@@ -31,7 +29,7 @@ This tool will batch test availability by sending out N ICMP-requests, and then 
 
 Hosts that do not reply will be marked in RED, others in GREEN with the response time shown in milliseconds.
 
-Efficiently implemented in C, zero polling, single socket for all N hosts.
+Efficiently implemented in C, zero polling, two sockets for all N hosts (one for all IPv4 connections, one for all IPv6 connections).
 
 
 ## Features

--- a/icmp_watch.c
+++ b/icmp_watch.c
@@ -40,6 +40,12 @@
 
 #define BGGRN	    ESC "[1;42m"
 
+struct destination_info {
+	int response_time;		// Response time in milliseconds
+	int error;				// errno if there was an error, 0 otherwise
+	struct sockaddr *address;			// pointer to either an sockadder_in or sockaddr_in6 struct
+};
+
 static struct termios orig_termios;    // The terminal settings before we modified it.
 
 void disableRawMode()
@@ -59,123 +65,191 @@ void enableRawMode()
 	tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
 }
 
-static int ping_all(int cnt, struct in6_addr* destinations, int* response_times, int* errors, struct timeval* timeout)
+static int ping_all(int cnt, struct destination_info* destinations, struct timeval* timeout)
 {
 	static int sequence = 0;
 	const int seq = sequence++;        // the sequence number we will use for this run.
 	const int waittime = (int) (timeout->tv_sec * 1000000 + timeout->tv_usec);
-	int sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_ICMPV6);
+	int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+	int sock6 = socket(AF_INET6, SOCK_DGRAM, IPPROTO_ICMPV6);
 	if (sock < 0)
 	{
 		perror("socket");
 		exit(4);
 	}
-
-	for (int i = 0; i < cnt; ++i) {
-		response_times[i] = -1;	  	// what we return if we did not get a reply.
-		errors[i] = 0;			  	// what we return if there wasn’t an error
+	if (sock6 < 0) {
+		perror("v6 socket");
+		exit(6);
 	}
 
-	// Send an ICMP request to each destination.
-	struct icmp6_hdr icmp6_hdr;
+	for (int i = 0; i < cnt; ++i) {
+		destinations[i].response_time = -1;	  	// what we return if we did not get a reply.
+		destinations[i].error = 0;			  	// what we return if there wasn’t an error
+	}
+	
+	// Prepare an ICMP(v4 and v6) request for each destination.
+	struct icmphdr icmp_hdr;
 	unsigned char txdata[256];
 	const int payloadsz = 10;
-	memcpy(txdata + sizeof icmp6_hdr, "icmp_watch", payloadsz);    // icmp payload
-	for (int i = 0; i < cnt; ++i)
-	{
-		struct sockaddr_in6 addr;
-		memset(&addr, 0, sizeof addr);
-		addr.sin6_family = AF_INET6;
-		addr.sin6_addr = destinations[i];
+	memcpy(txdata + sizeof icmp_hdr, "icmp_watch", payloadsz);    // icmp payload
+	
+	struct icmp6_hdr icmp6_hdr;
+	unsigned char tx6data[256];
+	memcpy(tx6data + sizeof icmp6_hdr, "icmp_watch", payloadsz);    // icmpv6 payload
 
-		memset(&icmp6_hdr, 0, sizeof icmp6_hdr);
-		icmp6_hdr.icmp6_type = ICMP6_ECHO_REQUEST;
-		icmp6_hdr.icmp6_id = 0xbeef;
+	// A fork in the road, as the code if different for v4 and v6
+	for (int i = 0; i < cnt; ++i) {
+		if (destinations[i].address->sa_family == AF_INET) {
+			destinations[i].error = ENOSYS;	// Not implemented
+			return 0;
+		} else if (destinations[i].address->sa_family == AF_INET6) {
+			struct sockaddr_in6 addr;
+			memset(&addr, 0, sizeof addr);
+			addr.sin6_family = AF_INET6;
+			addr.sin6_addr = ((struct sockaddr_in6 *) destinations[i].address)->sin6_addr;
 
-		icmp6_hdr.icmp6_seq = seq;
-		memcpy(txdata, &icmp6_hdr, sizeof icmp6_hdr);
-		int rc = sendto(sock, txdata, sizeof icmp6_hdr + payloadsz, 0, (struct sockaddr*) &addr, sizeof addr);
-		if (rc <= 0)
-		{
-			errors[i] = errno;
+			memset(&icmp6_hdr, 0, sizeof icmp6_hdr);
+			icmp6_hdr.icmp6_type = ICMP6_ECHO_REQUEST;
+			icmp6_hdr.icmp6_id = 0xbeef;
+
+			icmp6_hdr.icmp6_seq = seq;
+			memcpy(tx6data, &icmp6_hdr, sizeof icmp6_hdr);
+			int rc = sendto(sock6, tx6data, sizeof icmp6_hdr + payloadsz, 0, (struct sockaddr*) &addr, sizeof addr);
+			if (rc <= 0)
+			{
+				destinations[i].error = errno;
+			}
 		}
 	}
 
 	fd_set read_set;
 	memset(&read_set, 0, sizeof read_set);
+	int highestfd;
+	if (sock > sock6)
+		highestfd = sock;
+	else
+		highestfd = sock6;
 	FD_SET(sock, &read_set);
+	FD_SET(sock6, &read_set);
 
 	int num_replies = 0;
 	while (num_replies < cnt)
 	{
 		// wait for a reply with a timeout
-		const int rc0 = select(sock + 1, &read_set, NULL, NULL, timeout);
+		const int rc0 = select(highestfd + 1, &read_set, NULL, NULL, timeout);
 		if (rc0 == 0)
 		{
 			// Timed out without a reply.
 			close(sock);
+			close(sock6);
 			sock = 0;
+			sock6 = 0;
 			return num_replies;
 		}
 		else if (rc0 < 0)
 		{
 			close(sock);
+			close(sock6);
 			sock = 0;
+			sock6 = 0;
 			perror("select");
 			return -1;
 		}
-
-		unsigned char rcdata[256];
-		struct icmp6_hdr rcv_hdr;
-		struct sockaddr_in6 other_addr;
-		socklen_t other_addr_len = sizeof(other_addr);
-		const int rc1 = recvfrom(sock, rcdata, sizeof rcdata, 0, (struct sockaddr*) &other_addr, &other_addr_len);
-		if (rc1 <= 0)
-		{
-			perror("recvfrom");
-			exit(5);
+		
+		if (FD_ISSET(sock, &read_set)) {
+			/* IPv4 code */
+			unsigned char rcdata[256];
+			struct icmphdr rcv_hdr;
+			struct sockaddr_in other_addr;
+			socklen_t other_addr_len = sizeof(other_addr);
+			
+			const int rc1 = recvfrom(sock, rcdata, sizeof rcdata, 0, (struct sockaddr*) &other_addr, &other_addr_len);
+			if (rc1 <= 0)
+			{
+				perror("recvfrom");
+				exit(5);
+			}
+			if (rc1 < (int) sizeof(rcv_hdr))
+				exit(6);			// ICMP packet was too short.
+			memcpy(&rcv_hdr, rcdata, sizeof rcv_hdr);
+			assert(rcv_hdr.type == ICMP_ECHOREPLY);
+			if (rcv_hdr.un.echo.sequence == seq)	// The sequence number should match, otherwise it's not a valid response.
+			{
+				const struct in_addr send_addr = other_addr.sin_addr;
+				int idx = -1;
+				// Look up which host sent us this reply.
+				for (int j = 0; j < cnt; ++j)
+					if(((struct sockaddr_in* ) destinations[j].address)->sin_addr.s_addr != send_addr.s_addr) {
+						idx = j;
+						break;
+					}
+				assert(idx >= 0);
+				const int timeleft = (int) (timeout->tv_sec * 1000000 + timeout->tv_usec);
+				destinations[idx].response_time = waittime - timeleft;
+				num_replies += 1;
+			}
 		}
-		if (rc1 < (int) sizeof(rcv_hdr))
-			exit(6);			// ICMP packet was too short.
-		memcpy(&rcv_hdr, rcdata, sizeof rcv_hdr);
-		assert(rcv_hdr.icmp6_type == ICMP6_ECHO_REPLY);
-		if (rcv_hdr.icmp6_seq == seq)	// The sequence number should match, otherwise it's not a valid response.
-		{
-			const struct in6_addr send_addr = other_addr.sin6_addr;
-			int idx = -1;
-			// Look up which host sent us this reply.
-			for (int j = 0; j < cnt; ++j) {
-				// For IPv6 we have to compare all 16 unsigned chars of the address (128 bits)
-				int thisone = 1;
-				for(int x = 0; x < 16; x++) {
-					if(destinations[j].s6_addr[x] != send_addr.s6_addr[x]) {
-						thisone = 0;
+		if (FD_ISSET(sock6, &read_set)) {
+			/* IPv6 code */
+			unsigned char rcdata6[256];
+			struct icmp6_hdr rcv6_hdr;
+			struct sockaddr_in6 other_addr6;
+			socklen_t other_addr6_len = sizeof(other_addr6);
+
+			const int rc1v6 = recvfrom(sock6, rcdata6, sizeof rcdata6, 0, (struct sockaddr*) &other_addr6, &other_addr6_len);
+			if (rc1v6 <= 0) {
+				perror("recvfrom (v6)");
+				exit(5);
+			}
+			if (rc1v6 < (int) sizeof(rcv6_hdr))
+				exit(8);
+			
+			memcpy(&rcv6_hdr, rcdata6, sizeof rcv6_hdr);
+			assert(rcv6_hdr.icmp6_type == ICMP6_ECHO_REPLY);
+			if (rcv6_hdr.icmp6_seq == seq) {
+				// The sequence number should match, otherwise it's not a valid response
+				const struct in6_addr send6_addr = other_addr6.sin6_addr;
+				int idx = -1;
+				// Search for which host sent the reply
+				for (int j = 0; j < cnt; ++j) {
+					// For IPv6 we have to compare all 16 unsigned chars of the address (128 bits)
+					int thisone = 1;
+					for(int x = 0; x < 16; x++) {
+						if(((struct sockaddr_in6* ) destinations[j].address)->sin6_addr.s6_addr[x] != send6_addr.s6_addr[x]) {
+							thisone = 0;
+							break;
+						}
+					}
+					if (thisone) {
+						idx = j;
 						break;
 					}
 				}
-				if (thisone)
-					idx = j;
+				assert(idx >= 0);
+				const int timeleft = (int) (timeout->tv_sec * 1000000 + timeout->tv_usec);
+				destinations[idx].response_time = waittime - timeleft;
+				num_replies += 1;
 			}
-			assert(idx >= 0);
-			const int timeleft = (int) (timeout->tv_sec * 1000000 + timeout->tv_usec);
-			response_times[idx] = waittime - timeleft;
-			num_replies += 1;
 		}
 	}
+	
 	if (close(sock) < 0)
 		perror("close(socket)");
 	sock = 0;
+	
+	if (close(sock6) < 0)
+		perror("close(socket for v6)");
+	sock6 = 0;
 	return num_replies;
 }
 
 // Resolves a set of hostnames to IPv6 numbers. (they may be IPv4-mapped IPv6 addresses like ::ffff:127.0.0.1)
-static int get_ip_addresses(int cnt, char** hosts, struct in6_addr* ips)
+static int get_ip_addresses(int cnt, char** hosts, struct destination_info* destinations)
 {
 	struct addrinfo hints;
 	memset(&hints, 0, sizeof(hints));
-	hints.ai_family = AF_INET6;
+	hints.ai_family = AF_UNSPEC;
 	hints.ai_socktype = SOCK_DGRAM;
-	hints.ai_flags = AI_V4MAPPED | AI_ADDRCONFIG;
 	for (int i = 0; i < cnt; ++i)
 	{
 		struct addrinfo* infos;
@@ -188,8 +262,41 @@ static int get_ip_addresses(int cnt, char** hosts, struct in6_addr* ips)
 		}
 		for (struct addrinfo* inf = infos; inf != 0; inf = inf->ai_next)
 		{
-			struct sockaddr_in6* addr = (struct sockaddr_in6*) inf->ai_addr;
-			ips[i] = addr->sin6_addr;
+			// Check if the returned address was v4 or v6
+ 			switch(inf->ai_family) {
+				case AF_INET: {
+					// Copy the inf->ai_addr structure
+					// It'll need to be freed later with something like free(destinations->address)
+					struct sockaddr_in* copied_ai_addr = malloc(sizeof(struct sockaddr_in));
+					if(copied_ai_addr == NULL) {
+						// Check we actually got some memory, if not, exit
+						fprintf(stderr, "Failed allocate memory for copied_ai_addr!\n");
+						exit(EXIT_FAILURE);
+					}
+					memcpy(copied_ai_addr, inf->ai_addr, sizeof(struct sockaddr_in));
+					destinations->address = (struct sockaddr*) copied_ai_addr;
+					break;
+				}
+				case AF_INET6: {
+					// Copy the inf->ai_addr structure
+					// It'll need to be freed later with something like free(destinations->address)
+					struct sockaddr_in6* copied_ai_addr = malloc(sizeof(struct sockaddr_in6));
+					if(copied_ai_addr == NULL) {
+						// Check we actually got some memory, if not, exit
+						fprintf(stderr, "Failed allocate memory for copied_ai_addr!\n");
+						exit(EXIT_FAILURE);
+					}
+					memcpy(copied_ai_addr, inf->ai_addr, sizeof(struct sockaddr_in6));
+					destinations->address = (struct sockaddr*) copied_ai_addr;
+					break;
+				}
+				default: {
+					fprintf(stderr, "For %s, we got an address type (%i) that wasn't AF_INET (%i) or AF_INET6 (%i)", host, inf->ai_family, AF_INET, AF_INET6);
+					//exit(7);
+				}
+			}
+			//struct sockaddr_in6* addr = (struct sockaddr_in6*) inf->ai_addr;
+			//ips[i] = addr->sin6_addr;
 		}
 		freeaddrinfo(infos);
 	}
@@ -205,13 +312,12 @@ int main(int argc, char* argv[])
 	}
 
 	const int cnt = argc - 1;    // Every argument on command line is a hostname.
-	struct in6_addr dst[cnt];     // The IP numbers of the hosts.
-	int response_times[cnt];     // The response time for each host we ping.
-	int errors[cnt];             // The errno(3) for each host (0 if no error)
+	
+	struct destination_info destinations[cnt];
 
 	fprintf(stderr, "Looking up %d ip numbers...", cnt);
 	fflush(stderr);
-	const int num = get_ip_addresses(cnt, argv + 1, dst);
+	const int num = get_ip_addresses(cnt, argv + 1, destinations);
 	fprintf(stderr, "DONE\n");
 	if (num != cnt)
 	{
@@ -222,6 +328,7 @@ int main(int argc, char* argv[])
 	enableRawMode();    // Don't echo keyboard characters, don't buffer them.
 
 	int done = 0;
+	FILE *outputfd = fopen("/tmp/icmp_watch.txt", "w");
 	while (!done)
 	{
 		// When ESC or Q is pressed, we should terminate.
@@ -230,20 +337,20 @@ int main(int argc, char* argv[])
 		if (numr == 1 && (c == 27 || c == 'q' || c == 'Q'))
 			done = 1;
 		struct timeval timeout = {1, 0};    // seconds, microseconds.
-		ping_all(cnt, dst, response_times, errors, &timeout);
-		fprintf(stdout, CLEARSCREEN);
+		ping_all(cnt, destinations, &timeout);
+		fprintf(outputfd, CLEARSCREEN);
 		for (int i = 0; i < cnt; ++i)
 		{
-			const int t = response_times[i];
-			const int e = errors[i];
-			fprintf(stdout, "%-20s", argv[1 + i]);
+			const int t = destinations[i].response_time;
+			const int e = destinations[i].error;
+			fprintf(outputfd, "%-20s", argv[1 + i]);
 			if (t < 0)
 				if (e != 0)
-					fprintf(stdout, FGWHT BGRED "   ERROR" RESETALL " (%s)\n", strerror(e));
+					fprintf(outputfd, FGWHT BGRED "   ERROR" RESETALL " (%s)\n", strerror(e));
 				else
-					fprintf(stdout, FGWHT BGRED "NO REPLY" RESETALL "\n");
+					fprintf(outputfd, FGWHT BGRED "NO REPLY" RESETALL "\n");
 			else
-				fprintf(stdout, FGWHT BGGRN "%5d ms" RESETALL "\n", t / 1000);
+				fprintf(outputfd, FGWHT BGGRN "%5d ms" RESETALL "\n", t / 1000);
 		}
 		// Pace ourselves.
 		const int NS_PER_US = 1000;
@@ -251,7 +358,9 @@ int main(int argc, char* argv[])
 		struct timespec ts = {0, us_left * NS_PER_US};
 		nanosleep(&ts, 0);
 	}
-	fprintf(stdout, CLEARSCREEN);
+	fprintf(outputfd, CLEARSCREEN);
+	
+	fclose(outputfd);
 	return 0;
 }
 

--- a/icmp_watch.c
+++ b/icmp_watch.c
@@ -135,7 +135,6 @@ static int ping_all(int cnt, struct in6_addr* destinations, int* response_times,
 			perror("recvfrom");
 			exit(5);
 		}
-		printf("Type of other_addr was %i\n", other_addr.sin6_family);
 		if (rc1 < (int) sizeof(rcv_hdr))
 			exit(6);			// ICMP packet was too short.
 		memcpy(&rcv_hdr, rcdata, sizeof rcv_hdr);

--- a/icmp_watch.c
+++ b/icmp_watch.c
@@ -400,11 +400,21 @@ int main(int argc, char* argv[])
 				}
 			case '4':
 				// Only use IPv4
-				restrict_protocol = 4;
+				if (restrict_protocol == 0) {
+					restrict_protocol = 4;
+				} else {
+					fprintf(stderr, "Only one of -4 or -6 is accepted\n");
+					exit(1);
+				}
 				break;
 			case '6':
 				// Only use IPv6
-				restrict_protocol = 6;
+				if (restrict_protocol == 0) {
+					restrict_protocol = 6;
+				} else {
+					fprintf(stderr, "Only one of -4 or -6 is accepted\n");
+					exit(1);
+				}
 				break;
 			case 'h':
 				print_help(argv[0]);

--- a/icmp_watch.c
+++ b/icmp_watch.c
@@ -466,7 +466,7 @@ int main(int argc, char* argv[])
 		const int numr = read(STDIN_FILENO, &c, 1);
 		if (numr == 1 && (c == 27 || c == 'q' || c == 'Q'))
 			done = 1;
-		struct timeval timeout = default_timeout;    // seconds, microseconds.
+		struct timeval timeout = default_timeout;
 		ping_all(cnt, destinations, &timeout);
 		fprintf(stdout, CLEARSCREEN);
 		for (int i = 0; i < cnt; ++i)


### PR DESCRIPTION
Add support for pinging IPv6 hosts, alongside IPv4 hosts if you want
It also adds -4 and -6 options for restricting the addresses resolved by get_ip_addresses to only v4 or v6 addresses respectively

Changes:
* instead of passing response_times and errors to functions, an array of destination_info structs is passed instead, which combines the response time, error number and addresses of each destination (so one array rather than 3)
* another, separate socket is created for IPv6
* different code paths in the ping_all function for sending and receiving the hosts

I'm marking this as a draft because I've only tested it on my machine with my normal internet connection, which has a public IPv6 address (so I can ping IPv6 hosts just fine). I haven't tested it in different scenarios such as having IPv6 disabled or not having a public IPv6 address available, only having v6 addresses, etc.