### PR TITLE
Update icmp_watch.c

### DIFF
--- a/icmp_watch.c
+++ b/icmp_watch.c
@@ -241,6 +241,7 @@ int main(int argc, char* argv[])
 				exit(0);
 			default:
 				//fprintf(stderr, "getopt_long returned character code 0x%x\n", c);
+				;
 		}
 	} // Finished parsing command line options
 


### PR DESCRIPTION
Explicit closing `;` in switch case is needed for older compilers.

```$ make
cc -O2 -Wall icmp_watch.c -o icmp_watch
icmp_watch.c: In function ‘main’:
icmp_watch.c:242:4: error: label at end of compound statement
  242 |    default:
      |    ^~~~~~~
make: *** [Makefile:3: icmp_watch] Error 1

$ cc --version
cc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```